### PR TITLE
added teleporting on mese punch (configurable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This minetest mod adds a calibratable compass to the minetest. Original mod [her
    The new compass points to the origin / Zero point and is already usable.
 2. Punch the compass to a compatible node (all by default) and enter the target name
 3. Now this compass leads you allways to this location. You can give it away to allow other users to find this place.
-
+4. Punch a teleport compatible node (by default mese block) to teleport back to the calibrated place
 
 ## For server owners:
 The mod support the next settings:
@@ -23,6 +23,7 @@ The mod support the next settings:
     ccompass_restrict_target (Disabled by default): If enabled, only specific nodes are allowed for calibration (usable with any type waypoint nodes for example)
     ccompass_restrict_target_nodes: List of technical node names allowed for compass calibration, separated by ','
     ccompass_aliasses: If enabled the compas:* items will be aliased to the ccompass:* items for compatibility
+    ccompass_teleport_nodes: List of technical node names that triggers the teleport to destination, separated by ','
 
 
 ##  For developers:
@@ -32,6 +33,7 @@ The mod support the next settings:
 	ccompass.recalibrate = true
 	ccompass.restrict_target = true
 	ccompass.restrict_target_nodes["schnitzeljagd:waypoint"] = true
+	ccompass.teleport_nodes["default:diamondblock"] = true
 ```
 
 2. The pointed node metadata will be checked for "waypoint_name" attribute. It this attribute is set, the calibration screen take this string as proposal. This can be used for a game specific calibration node. To get it working working just set in node definition something like

--- a/init.lua
+++ b/init.lua
@@ -79,27 +79,27 @@ local function get_destination(player, stack)
 end
 
 local function teleport_above(playername, target, counter)
-		local player = minetest.get_player_by_name(playername)
-		if not player then
+	local player = minetest.get_player_by_name(playername)
+	if not player then
+		return
+	end
+
+	for i = (counter or 1), 160 do
+		local nodename = minetest.get_node(target).name
+		if nodename == "ignore" then
+			minetest.emerge_area(target, target)
+			minetest.after(0.1, teleport_above, playername, target, i)
 			return
 		end
 
-		for i = (counter or 1), 160 do
-			local nodename = minetest.get_node(target).name
-			if nodename == "ignore" then
-				minetest.emerge_area(target, target)
-				minetest.after(0.1, teleport_above, playername, target, i)
-				return
-			end
-
-			if nodename ~= 'air' then
-				target.y = target.y + 1
-			else
-				break
-			end
+		if nodename ~= 'air' then
+			target.y = target.y + 1
+		else
+			break
 		end
-		player:setpos(target)
-		return
+	end
+	player:setpos(target)
+	return
 end
 
 -- get right image number for players compas

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -9,3 +9,6 @@ ccompass_restrict_target_nodes (Nodes list allowed for calibration) string
 
 # Enable aliasses to replace other compass mods
 ccompass_aliasses (Enable compatibility aliasses) bool false
+
+# Nodes able to teleport to destination on punch, separated by ','
+ccompass_teleport_nodes (Nodes list for teleport on punch) string default:mese


### PR DESCRIPTION
If compass is punched to a "magic node" by default mese block, the player is teleported to calibrated compass destination.
Note, the mese block is to expensive to be leave behind, so use this function advisedly, and do not forgot the ccompass with calibrated for come back