### PR TITLE
Propose multi air

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The mod support the next settings:
     ccompass_teleport_nodes: List of technical node names that triggers the teleport to destination, separated by ','
     ccompass_nodes_over_target_allow: List of additional node names that must be above target for teleport to be executed. (separated by ',')
     ccompass_nodes_over_target_deny: List of additional node names that must NOT be above target for teleport to be executed. (separated by ',')
+    ccompass_nodes_over_target_allow_drawtypes: List of drawtypes to allow to be over target. Defaults are: airlike, flowingliquid, liquid, plantlike and plantlike_rooted
+    ccompass_deny_climbable_target: Disabled by default -> allows climbable nodes to be over target. Set to true to not allow them.
 
 ##  For developers:
 1. It is possible to change compass settings from other mods by changing values in global table ccompass. So it is possible for example to add a waypoint node to the target-nodes by
@@ -37,9 +39,15 @@ The mod support the next settings:
 	ccompass.teleport_nodes["default:diamondblock"] = true
 	ccompass.nodes_over_target_allow["vacuum:vacuum"] = true
 	ccompass.nodes_over_target_deny["tnt:boom"] = true
+	ccompass.nodes_over_target_allow_drawtypes["liquid"] = nil
+	ccompass.allow_climbable_target = false
 ```
 Also you can override ccompass.is_safe_target(target, nodename) for more granular checks.
-By default first nodes_over_target_allow is checked, then nodes_over_target_deny and finally nodes are checked for damaging and airlike drawtype.
+By default first nodes_over_target_allow is checked, then nodes_over_target_deny
+and finally nodes are checked for damaging and airlike drawtype.
+
+Similarly you can override ccompass.is_safe_target_under(target, nodename) for
+more granular checks on what is under players feet.
 
 2. The pointed node metadata will be checked for "waypoint_name" attribute. It this attribute is set, the calibration screen take this string as proposal. This can be used for a game specific calibration node. To get it working working just set in node definition something like
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The mod support the next settings:
     ccompass_restrict_target_nodes: List of technical node names allowed for compass calibration, separated by ','
     ccompass_aliasses: If enabled the compas:* items will be aliased to the ccompass:* items for compatibility
     ccompass_teleport_nodes: List of technical node names that triggers the teleport to destination, separated by ','
+    ccompass_air_nodes: List of node names that must be above target for teleport to be executed. (separated by ',')
 
 
 ##  For developers:
@@ -34,6 +35,7 @@ The mod support the next settings:
 	ccompass.restrict_target = true
 	ccompass.restrict_target_nodes["schnitzeljagd:waypoint"] = true
 	ccompass.teleport_nodes["default:diamondblock"] = true
+	ccompass.air_nodes["bamboo:trunk"] = true
 ```
 
 2. The pointed node metadata will be checked for "waypoint_name" attribute. It this attribute is set, the calibration screen take this string as proposal. This can be used for a game specific calibration node. To get it working working just set in node definition something like
@@ -71,3 +73,4 @@ The mod support the next settings:
         return modified_compass_stack
     end
 ```
+

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The mod support the next settings:
     ccompass_restrict_target_nodes: List of technical node names allowed for compass calibration, separated by ','
     ccompass_aliasses: If enabled the compas:* items will be aliased to the ccompass:* items for compatibility
     ccompass_teleport_nodes: List of technical node names that triggers the teleport to destination, separated by ','
-    ccompass_air_nodes: List of node names that must be above target for teleport to be executed. (separated by ',')
-
+    ccompass_nodes_over_target_allow: List of additional node names that must be above target for teleport to be executed. (separated by ',')
+    ccompass_nodes_over_target_deny: List of additional node names that must NOT be above target for teleport to be executed. (separated by ',')
 
 ##  For developers:
 1. It is possible to change compass settings from other mods by changing values in global table ccompass. So it is possible for example to add a waypoint node to the target-nodes by
@@ -35,8 +35,11 @@ The mod support the next settings:
 	ccompass.restrict_target = true
 	ccompass.restrict_target_nodes["schnitzeljagd:waypoint"] = true
 	ccompass.teleport_nodes["default:diamondblock"] = true
-	ccompass.air_nodes["bamboo:trunk"] = true
+	ccompass.nodes_over_target_allow["vacuum:vacuum"] = true
+	ccompass.nodes_over_target_deny["tnt:boom"] = true
 ```
+Also you can override ccompass.is_safe_target(target, nodename) for more granular checks.
+By default first nodes_over_target_allow is checked, then nodes_over_target_deny and finally nodes are checked for damaging and airlike drawtype.
 
 2. The pointed node metadata will be checked for "waypoint_name" attribute. It this attribute is set, the calibration screen take this string as proposal. This can be used for a game specific calibration node. To get it working working just set in node definition something like
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The mod support the next settings:
     ccompass_nodes_over_target_deny: List of additional node names that must NOT be above target for teleport to be executed. (separated by ',')
     ccompass_nodes_over_target_allow_drawtypes: List of drawtypes to allow to be over target. Defaults are: airlike, flowingliquid, liquid, plantlike and plantlike_rooted
     ccompass_deny_climbable_target: Disabled by default -> allows climbable nodes to be over target. Set to true to not allow them.
+    ccompass_allow_damage_target: Disabled by default -> will not teleport player into or over damaging nodes.
 
 ##  For developers:
 1. It is possible to change compass settings from other mods by changing values in global table ccompass. So it is possible for example to add a waypoint node to the target-nodes by
@@ -41,6 +42,7 @@ The mod support the next settings:
 	ccompass.nodes_over_target_deny["tnt:boom"] = true
 	ccompass.nodes_over_target_allow_drawtypes["liquid"] = nil
 	ccompass.allow_climbable_target = false
+	ccompass.allow_damaging_target = true
 ```
 Also you can override ccompass.is_safe_target(target, nodename) for more granular checks.
 By default first nodes_over_target_allow is checked, then nodes_over_target_deny

--- a/init.lua
+++ b/init.lua
@@ -106,6 +106,8 @@ function ccompass.is_safe_target(target, nodename)
 	if node_def.damage_per_second and 0 < node_def.damage_per_second then
 		return false
 	end
+	-- climbable nodes are ok
+	if node_def.climbable then return true end
 	-- deeper checks
 	local is_good_draw_type = {
 		airlike = true,

--- a/init.lua
+++ b/init.lua
@@ -148,9 +148,13 @@ function ccompass.is_safe_target_under(target, nodename)
 			return false
 		end
 	end
+	-- climbable nodes are ok depending on settings
+	if ccompass.allow_climbable_target and node_def.climbable then return true end
+	-- solid / walkable
+	if node_def.walkable then return true end
 
-	-- anything else is assumed safe
-	return true
+	-- anything else is assumed unsafe
+	return false
 end
 
 local function teleport_above(playername, target, counter)

--- a/init.lua
+++ b/init.lua
@@ -139,11 +139,6 @@ function ccompass.is_safe_target(target, nodename)
 end
 
 function ccompass.is_safe_target_under(target, nodename)
-	-- for games with target node restriction
-	if ccompass.restrict_target and not ccompass.restrict_target_nodes[nodename] then
-		return false
-	end
-
 	local node_def = minetest.registered_nodes[nodename]
 	-- unknown node: not dangerous but probably best treated as one
 	if not node_def then return false end

--- a/init.lua
+++ b/init.lua
@@ -29,6 +29,23 @@ if teleport_nodes_setting then
 else
 	ccompass.teleport_nodes["default:mese"] = true
 end
+-- Permited nodes above target
+ccompass.air_nodes = {}
+local air_nodes_setting = minetest.settings:get("ccompass_air_nodes")
+if air_nodes_setting then
+	air_nodes_setting:gsub("[^,]+", function(z)
+		ccompass.air_nodes[z] = true
+	end)
+else
+	ccompass.air_nodes["air"] = true
+	ccompass.air_nodes["bridger:scaffolding"] = true
+	ccompass.air_nodes["default:river_water_flowing"] = true
+	ccompass.air_nodes["default:river_water_source"] = true
+	ccompass.air_nodes["default:water_flowing"] = true
+	ccompass.air_nodes["default:water_source"] = true
+	ccompass.air_nodes["planet_mars:airlight"] = true
+	ccompass.air_nodes["vacuum:vacuum"] = true
+end
 
 if minetest.settings:get_bool("ccompass_aliasses") then
 	minetest.register_alias("compass:0", "ccompass:0")
@@ -93,17 +110,18 @@ local function teleport_above(playername, target, counter)
 			return
 		end
 
-		if nodename ~= 'air' then
-			target.y = target.y + 1
-		else
+		if ccompass.air_nodes[nodename] then
 			found_place = true
 			break
+		else
+			target.y = target.y + 1
 		end
 	end
+
 	if found_place then
 		player:setpos(target)
 	else
-		minetest.chat_send_player(playername, "Could not find air at target.")
+		minetest.chat_send_player(playername, "Could not find suitable surrounding at target.")
 	end
 end
 

--- a/init.lua
+++ b/init.lua
@@ -21,6 +21,7 @@ if nodes_setting then
 end
 
 ccompass.allow_climbable_target = not minetest.settings:get_bool("ccompass_deny_climbable_target")
+ccompass.allow_damaging_target = minetest.settings:get_bool("ccompass_allow_damage_target")
 
 -- Teleport targets
 ccompass.teleport_nodes = {}
@@ -122,8 +123,10 @@ function ccompass.is_safe_target(target, nodename)
 	-- black-list
 	if ccompass.nodes_over_target_deny[nodename] then return false end
 	-- damaging node
-	if node_def.damage_per_second and 0 < node_def.damage_per_second then
-		return false
+	if not ccompass.allow_damaging_target then
+		if node_def.damage_per_second and 0 < node_def.damage_per_second then
+			return false
+		end
 	end
 	-- climbable nodes are ok depending on settings
 	if ccompass.allow_climbable_target and node_def.climbable then return true end
@@ -145,8 +148,10 @@ function ccompass.is_safe_target_under(target, nodename)
 	-- unknown node: not dangerous but probably best treated as one
 	if not node_def then return false end
 	-- damaging node
-	if node_def.damage_per_second and 0 < node_def.damage_per_second then
-		return false
+	if not ccompass.allow_damaging_target then
+		if node_def.damage_per_second and 0 < node_def.damage_per_second then
+			return false
+		end
 	end
 
 	-- anything else is assumed safe

--- a/init.lua
+++ b/init.lua
@@ -84,6 +84,7 @@ local function teleport_above(playername, target, counter)
 		return
 	end
 
+	local found_place = false
 	for i = (counter or 1), 160 do
 		local nodename = minetest.get_node(target).name
 		if nodename == "ignore" then
@@ -95,11 +96,15 @@ local function teleport_above(playername, target, counter)
 		if nodename ~= 'air' then
 			target.y = target.y + 1
 		else
+			found_place = true
 			break
 		end
 	end
-	player:setpos(target)
-	return
+	if found_place then
+		player:setpos(target)
+	else
+		minetest.chat_send_player(playername, "Could not find air at target.")
+	end
 end
 
 -- get right image number for players compas
@@ -248,3 +253,4 @@ minetest.register_craft({
 		{'', 'default:steel_ingot', ''}
 	}
 })
+

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -29,3 +29,7 @@ ccompass_nodes_over_target_deny (Nodes list for additional deny nodes) string
 # String list of node names separated by ','
 ccompass_nodes_over_target_allow_drawtypes (Drawtypes of nodes allowed over target) string airlike,flowingliquid,liquid,plantlike,plantlike_rooted
 
+# By default ccompass will not teleport players into or over damaging nodes.
+# To allow this, change to true.
+ccompass_allow_damage_target (Enable to allow teleporting into damaging nodes) bool false
+

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -12,3 +12,12 @@ ccompass_aliasses (Enable compatibility aliasses) bool false
 
 # Nodes able to teleport to destination on punch, separated by ','
 ccompass_teleport_nodes (Nodes list for teleport on punch) string default:mese
+
+# If one of these nodes is at target, skip other checks and allow teleporting.
+# String list of node names separated by ','
+ccompass_nodes_over_target_allow (Nodes list for additional allowed nodes) string
+
+# If one of these nodes is at target, skip other checks and deny teleporting.
+# String list of node names separated by ','
+ccompass_nodes_over_target_deny (Nodes list for additional deny nodes) string
+

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -4,6 +4,9 @@ ccompass_recalibrate (Allow compass recalibration) bool true
 # If disabled (default) all nodes are allowed to be compass target
 ccompass_restrict_target (Restrict nodes usable for calibration) bool false
 
+# If enabled, climbable nodes above target are considered unsafe.
+ccompass_deny_climbable_target (Deny climbable node above target) bool false
+
 # List of technical node names allowed for compass calibration, separated by ','
 ccompass_restrict_target_nodes (Nodes list allowed for calibration) string
 
@@ -20,4 +23,9 @@ ccompass_nodes_over_target_allow (Nodes list for additional allowed nodes) strin
 # If one of these nodes is at target, skip other checks and deny teleporting.
 # String list of node names separated by ','
 ccompass_nodes_over_target_deny (Nodes list for additional deny nodes) string
+
+# Drawtype of nodes over target that are considered safe. This will only be checked
+# checked after ccompass_nodes_over_target_allow and ccompass_nodes_over_target_deny.
+# String list of node names separated by ','
+ccompass_nodes_over_target_allow_drawtypes (Drawtypes of nodes allowed over target) string airlike,flowingliquid,liquid,plantlike,plantlike_rooted
 


### PR DESCRIPTION
If target position is in vacuum or is no longer in air,
compass would place player at 160 nodes above target no matter what is
there, including lava.
This fixes that.

Also proposal for multiple allowed and configurable nodes that must be above target node.

tag:not-tested