### PR TITLE
add an alternative recipe for "ccompass:0"

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -391,4 +391,13 @@ minetest.register_craft({
 		{'', 'default:steel_ingot', ''}
 	}
 })
+-- add an alternative recipe
+minetest.register_craft({
+	output = 'ccompass:0',
+	recipe = {
+		{'default:steel_ingot', '', 'default:steel_ingot'},
+		{'', 'default:mese_crystal_fragment', ''},
+		{'default:steel_ingot', '', 'default:steel_ingot'}
+	}
+})
 


### PR DESCRIPTION
This adds an alternative recipe for "ccompass:0", because the current one collides with "digtron:digtron_core".

See https://github.com/minetest-mods/digtron/blob/843dbd227658a93ee4df791bfdd3d136ee7adf85/nodes/recipes.lua#L13