### PR TITLE
Idle when no player has an active compass

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The mod support the next settings:
     ccompass_allow_damage_target: Disabled by default -> will not teleport player into or over damaging nodes.
     ccompass_stack_max: 1 by default. Sets maximum stack size, 1 to 65535
     ccompass_allow_using_stacks: Disabled by default -> calibrating and teleporting only works when single compass in hand. Setting to true, allows callibrating stacks to same location.
+    ccompass_idle_interval: 1 by default. When no players have active compasses, the mod enters an idle state and only checks for compasses at this interval, measured in seconds. This setting is meant to reduce the load on the server.
 
 ##  For developers:
 1. It is possible to change compass settings from other mods by changing values in global table ccompass. So it is possible for example to add a waypoint node to the target-nodes by
@@ -49,6 +50,7 @@ The mod support the next settings:
 	ccompass.allow_damaging_target = true
 	ccompass.allow_using_stacks = true
 	ccompass.stack_max = 42
+	ccompass.idle_interval = 0
 ```
 Also you can override ccompass.is_safe_target(target, nodename) for more granular checks.
 By default first nodes_over_target_allow is checked, then nodes_over_target_deny

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -39,3 +39,5 @@ ccompass_stack_max (Sets maximum stack size) int 1 1 65535
 # Requires stack_max greater than 1. When true, allows a whole stack to be calibrated at the same time.
 ccompass_allow_using_stacks (Enable to allow callibrating stacks) bool false
 
+# When no players have active compasses, the mod enters an idle state and only checks for compasses at this interval, measured in seconds. This setting is meant to reduce the load on the server.
+ccompass_idle_interval (Time between checks when idling) float 1 0 10


### PR DESCRIPTION
When the mod looks for compasses to update and finds none, it waits 1 second (or a different interval depending on the setting) before checking again. This avoids the need to look through the inventory of every player on every globalstep.

The cost is that there's an average of half a second of lag between when a compass is put in someone's hotbar and when it starts pointing the right direction. Personally, I don't think this is a big issue, but others may disagree.